### PR TITLE
CASMPET-5602: use updated image location

### DIFF
--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -1,6 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: sealed-secrets
-version: 0.2.0
+version: 0.3.0
 description: Cray Sealed Secrets
 keywords:
   - sealed-secrets
@@ -26,5 +49,5 @@ annotations:
           url: https://github.com/Cray-HPE/sealed-secrets/pull/3
   artifacthub.io/images: |
     - name: sealed-secrets-controller
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/bitnami/sealed-secrets-controller:v0.12.1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/sealed-secrets-controller:v0.12.1
   artifacthub.io/license: MIT

--- a/charts/sealed-secrets/values.yaml
+++ b/charts/sealed-secrets/values.yaml
@@ -1,6 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 sealed-secrets:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/quay.io/bitnami/sealed-secrets-controller
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/sealed-secrets-controller
     tag: v0.12.1
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary and Scope

This PR updates the chart to use the new updated image location. The minor version was bumped from 0.2.0 to 0.3.0.

## Issues and Related PRs

* Resolves [CASMPET-5602](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5602)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Updated the chart with the image, and made sure the secrets were unsealed successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

