### PR TITLE
CASMPET-6174: Bump chart to 0.4.0

### DIFF
--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: sealed-secrets
-version: 0.3.0
+version: 0.4.0
 description: Cray Sealed Secrets
 keywords:
   - sealed-secrets
@@ -49,5 +49,5 @@ annotations:
           url: https://github.com/Cray-HPE/sealed-secrets/pull/3
   artifacthub.io/images: |
     - name: sealed-secrets-controller
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/sealed-secrets-controller:v0.12.1
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/bitnami-labs/sealed-secrets-controller:v0.19.3
   artifacthub.io/license: MIT

--- a/charts/sealed-secrets/values.yaml
+++ b/charts/sealed-secrets/values.yaml
@@ -23,8 +23,8 @@
 #
 sealed-secrets:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/sealed-secrets-controller
-    tag: v0.12.1
+    repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/bitnami-labs/sealed-secrets-controller
+    tag: v0.19.3
     pullPolicy: IfNotPresent
 
   resources: {}


### PR DESCRIPTION
Updating to ghcr.io/bitnami-labs/sealed-secrets-controller:v0.19.3

## Summary and Scope

Updating chart to use a version of sealed secrets controller that works with k8s 1.22.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-6174
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Validated with this new sealed secrets controller with a vshasta v2 system to measure impact. Couldn't find any differences in anything tested. 

### Tested on:

  * Virtual Shasta (Caleb)

### Test description:

Installed new sealed secrets and validated I could extract existing secrets and created a few new secrets as well.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No known issues but I'm sure murphy will strike in unknown ways like an angry hungry kitten.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

