### PR TITLE
Casmpet 7381: Upgrade sealed-secrets to 0.28.0 for upgrade in CSM 1.7

### DIFF
--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -31,7 +31,7 @@ home: https://github.com/Cray-HPE/sealed-secrets
 dependencies:
   - name: sealed-secrets
     version: 2.17.1
-    repository: https://bitnami-labs.github.io/sealed-secrets
+    repository: https://bitnami-labs.github.io
 maintainers:
   - name: kburns-hpe
   - name: brantk-hpe

--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -23,23 +23,21 @@
 #
 apiVersion: v2
 name: sealed-secrets
-version: 0.4.1
+version: 0.5.0
 description: Cray Sealed Secrets
 keywords:
   - sealed-secrets
 home: https://github.com/Cray-HPE/sealed-secrets
 dependencies:
   - name: sealed-secrets
-    # note: https://github.com/helm/charts/commits/master/stable/sealed-secrets is deprecated now, we're super behind this is the new versioning scheme
-#    version: 1.0.4
-    version: 1.4.1
-    repository: https://charts.bitnami.com/bitnami
+    version: 2.17.1
+    repository: https://bitnami-labs.github.io/sealed-secrets
 maintainers:
   - name: kburns-hpe
   - name: brantk-hpe
   - name: rnoska-hpe
   - name: bo-quan
-appVersion: 0.21.0  # Tracks sealed-secrets child chart
+appVersion: 0.28.0  # Tracks sealed-secrets child chart
 annotations:
   artifacthub.io/changes: |
     - kind: security
@@ -51,5 +49,5 @@ annotations:
           url: https://github.com/Cray-HPE/sealed-secrets/pull/3
   artifacthub.io/images: |
     - name: sealed-secrets-controller
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/bitnami-labs/sealed-secrets-controller:v0.19.3
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/sealed-secrets-controller:0.28.0
   artifacthub.io/license: MIT

--- a/charts/sealed-secrets/values.yaml
+++ b/charts/sealed-secrets/values.yaml
@@ -25,7 +25,7 @@ sealed-secrets:
   image:
     registry: artifactory.algol60.net/csm-docker/stable/docker.io
     repository: bitnami/sealed-secrets
-    tag: 0.21.0-scratch-r0
+    tag: 0.28.0
     pullPolicy: IfNotPresent
 
   resources: {}


### PR DESCRIPTION
## Summary and Scope

Update sealed-secrets to 0.28.0 for updgrade in CSM 1.7.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

```
# kubectl describe pod sealed-secrets-59d75cc44c-s5jbp -n kube-system | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/sealed-secrets-controller:0.28.0
```

```
# kubectl create secret generic my-secret --from-literal=mykey=myvalue -n default
# kubectl get secrets -n default | grep my-secret
my-secret                        Opaque   1      14s
# kubectl describe secret my-secret -n default
Name:         my-secret
Namespace:    default
Labels:       <none>
Annotations:  <none>

Type:  Opaque

Data
====
mykey:  7 bytes
# kubectl get secret my-secret -n default -o jsonpath="{.data.mykey}" | base64 --decode
myvalue
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

