### PR TITLE
Fix Snyk workflow testing for sealed-secrets

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -13,8 +13,8 @@ jobs:
     with:
       lint-charts: ${{ github.event_name == 'pull_request' }}
       test-charts: false
-      snyk_exclude_app_vulns: true
       scan-chart-snyk-args: "--severity-threshold=high --policy-path=charts/.snyk"
+      scan-image-snyk-args: "--severity-threshold=high"
     secrets:
       snyk-token: ${{ secrets.SNYK_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: sealed-secrets
-version: 0.5.0
+version: 0.5.1
 description: Cray Sealed Secrets
 keywords:
   - sealed-secrets

--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: sealed-secrets
-version: 0.5.1
+version: 0.5.0
 description: Cray Sealed Secrets
 keywords:
   - sealed-secrets


### PR DESCRIPTION
## Summary and Scope

The github workflow for running Snyk vulnerability testing hasn't been updated in this repo for a while and seems to have gotten out of date.

## Testing:

Previous error:
```
The workflow is not valid. .github/workflows/charts-lint-test-scan.yml (Line: 16, Col: 31): Invalid input, snyk_exclude_app_vulns is not defined in the referenced workflow.
```

https://github.com/Cray-HPE/sealed-secrets/actions/runs/13272879822/job/37056233071?pr=10 showing a passed run for the chart and iamge.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

