### PR TITLE
CASMPET-7418: Remove PSP for k8s 1.32 compatibility

### DIFF
--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: sealed-secrets
-version: 0.5.0
+version: 0.5.1
 description: Cray Sealed Secrets
 keywords:
   - sealed-secrets

--- a/charts/sealed-secrets/values.yaml
+++ b/charts/sealed-secrets/values.yaml
@@ -44,7 +44,7 @@ sealed-secrets:
   rbac:
     # rbac.create: `true` if rbac resources should be created
     create: true
-    pspEnabled: true
+    pspEnabled: false
 
   # secretName: The name of the TLS secret containing the key used to encrypt secrets
   secretName: "sealed-secrets-key"


### PR DESCRIPTION
## Summary and Scope

After attempting the upgrades of my components with k8s 1.32 on Wasp, I uncovered some outstanding PSPs that need to be removed in order to make those 1.32 compatible. 

## Issues and Related PRs

* Related to [CASMPET-7418](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7418)

## Testing

### Tested on:

  * `wasp` with 1.32

### Test description:

Before:
```
# helm upgrade -n kube-system sealed-secrets ./sealed-secrets-0.5.0.tgz  -f values.yaml
Error: UPGRADE FAILED: resource mapping not found for name: "sealed-secrets" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first
```

After:
```
# helm upgrade -n kube-system sealed-secrets ./sealed-secrets-0.5.0.tgz  -f values.yaml
Release "sealed-secrets" has been upgraded. Happy Helming!
NAME: sealed-secrets
LAST DEPLOYED: Wed Mar 12 16:34:45 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
A Cray-specific Sealed Secrets chart
```

## Risks and Mitigations

Low risk


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

