### PR TITLE
CASMPET-7612 : Add CRD Update Functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021,2025 Hewlett Packard Enterprise Development LP
 
 CHART_METADATA_IMAGE ?= artifactory.algol60.net/csm-docker/stable/chart-metadata
 YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4
@@ -21,6 +21,25 @@ helm:
 
 dep-up:
 	CMD="dep up charts/sealed-secrets" $(MAKE) helm
+	$(MAKE) copy-crds
+
+copy-crds:
+	@echo "Copying CRDs from dependency chart to files directory..."
+	@mkdir -p charts/sealed-secrets/files
+	@cd charts/sealed-secrets/charts && \
+	if ls sealed-secrets-*.tgz > /dev/null 2>&1; then \
+		echo "Extracting dependency chart to access CRDs..."; \
+		tar -xzf sealed-secrets-*.tgz; \
+		if [ -d "sealed-secrets/crds" ]; then \
+			cp -r sealed-secrets/crds/* ../files/; \
+			echo "CRDs copied successfully"; \
+		else \
+			echo "Warning: CRDs directory not found in extracted dependency chart"; \
+		fi; \
+		rm -rf sealed-secrets; \
+	else \
+		echo "Warning: Dependency chart tgz file not found"; \
+	fi
 
 lint:
 	CMD="lint charts/sealed-secrets" $(MAKE) helm

--- a/Makefile
+++ b/Makefile
@@ -27,18 +27,15 @@ copy-crds:
 	@echo "Copying CRDs from dependency chart to files directory..."
 	@mkdir -p charts/sealed-secrets/files
 	@cd charts/sealed-secrets/charts && \
-	if ls sealed-secrets-*.tgz > /dev/null 2>&1; then \
-		echo "Extracting dependency chart to access CRDs..."; \
-		tar -xzf sealed-secrets-*.tgz; \
-		if [ -d "sealed-secrets/crds" ]; then \
-			cp -r sealed-secrets/crds/* ../files/; \
+	if [ -f sealed-secrets-*.tgz ]; then \
+		echo "Extracting dependency chart CRDs..."; \
+		if tar -xzf sealed-secrets-*.tgz -C ../files --strip-components 2 sealed-secrets/crds/bitnami.com_sealedsecrets.yaml; then \
 			echo "CRDs copied successfully"; \
 		else \
-			echo "Warning: CRDs directory not found in extracted dependency chart"; \
+			echo "Warning: Failed to extract CRDs from dependency chart"; \
 		fi; \
-		rm -rf sealed-secrets; \
 	else \
-		echo "Warning: Dependency chart tgz file not found"; \
+		echo "Warning: Dependency chart sealed-secrets-*.tgz file not found"; \
 	fi
 
 lint:

--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: sealed-secrets
-version: 0.5.1
+version: 0.5.2
 description: Cray Sealed Secrets
 keywords:
   - sealed-secrets
@@ -37,6 +37,7 @@ maintainers:
   - name: brantk-hpe
   - name: rnoska-hpe
   - name: bo-quan
+  - name: arka-pramanik-hpe
 appVersion: 0.28.0  # Tracks sealed-secrets child chart
 annotations:
   artifacthub.io/changes: |

--- a/charts/sealed-secrets/templates/01-crd-configmap.yaml
+++ b/charts/sealed-secrets/templates/01-crd-configmap.yaml
@@ -31,4 +31,4 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 data:
   bitnami.com_sealedsecrets.yaml: |-
-    {{- .Files.Get "charts/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml" | nindent 4 }}
+    {{- .Files.Get "files/bitnami.com_sealedsecrets.yaml" | nindent 4 }}

--- a/charts/sealed-secrets/templates/01-crd-configmap.yaml
+++ b/charts/sealed-secrets/templates/01-crd-configmap.yaml
@@ -1,0 +1,34 @@
+{{- /*
+MIT License
+
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "sealed-secrets-crd-configmap"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  bitnami.com_sealedsecrets.yaml: |-
+    {{- .Files.Get "charts/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml" | nindent 4 }}

--- a/charts/sealed-secrets/templates/02-rbac.yaml
+++ b/charts/sealed-secrets/templates/02-rbac.yaml
@@ -1,0 +1,60 @@
+{{/*
+MIT License
+
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+## ClusterRole that allows cluster-wide access to manage CRDs 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  creationTimestamp: null
+  name: sealed-secrets-crd-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+---
+## Bind the role to the sealed-secrets service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sealed-secrets-crd-rolebinding
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sealed-secrets-crd-role
+subjects:
+- kind: ServiceAccount
+  name: "sealed-secrets"
+  namespace: {{ .Release.Namespace }}

--- a/charts/sealed-secrets/templates/03-update-crd-job.yaml
+++ b/charts/sealed-secrets/templates/03-update-crd-job.yaml
@@ -1,0 +1,58 @@
+{{- /*
+MIT License
+
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "sealed-secrets-pre-upgrade-crd-hook"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      name: "sealed-secrets-pre-upgrade-crd-hook"
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: "sealed-secrets"
+      volumes:
+        - name: "sealed-secrets-crd-configmap"
+          configMap:
+            name: "sealed-secrets-crd-configmap"
+            defaultMode: 0755
+      restartPolicy: Never
+      containers:
+        - name: sealed-secrets-pre-upgrade-crd-hook
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          volumeMounts:
+           - name: "sealed-secrets-crd-configmap"
+             mountPath: /tmp
+          command:
+            - '/bin/sh'
+          args:
+            - "-c"
+            - kubectl apply -f /tmp/bitnami.com_sealedsecrets.yaml

--- a/charts/sealed-secrets/templates/03-update-crd-job.yaml
+++ b/charts/sealed-secrets/templates/03-update-crd-job.yaml
@@ -50,9 +50,9 @@ spec:
           imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
           volumeMounts:
            - name: "sealed-secrets-crd-configmap"
-             mountPath: /tmp
+             mountPath: /crds
           command:
             - '/bin/sh'
           args:
             - "-c"
-            - kubectl apply -f /tmp/bitnami.com_sealedsecrets.yaml
+            - kubectl apply -f /crds/bitnami.com_sealedsecrets.yaml

--- a/charts/sealed-secrets/values.yaml
+++ b/charts/sealed-secrets/values.yaml
@@ -66,3 +66,9 @@ sealed-secrets:
   podLabels: {}
 
   priorityClassName: ""
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.24.17
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

The sealedsecrets.bitnami.com CRDs from the sealed-secrets chart have not been updated during an upgrade to CSM 1.7.

When comparing the sealedsecrets.bitnami.com on a fresh CSM 1.7 install vs. a CSM 1.6 -> 1.7 upgrade, it was observed that the CRDs did not get updated during the upgrade.

Note that helm will not update CRDs during a chart upgrade, that has to be handled manually. This change handles this.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7612](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7612)
* EPIC LINK : https://jira-pro.it.hpe.com:8443/browse/CASMPET-7611

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `drax`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? 
- Was upgrade tested? y
- Was downgrade tested? 
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

